### PR TITLE
Return unicode instead of str

### DIFF
--- a/ovhcli/formater/terminal.py
+++ b/ovhcli/formater/terminal.py
@@ -36,7 +36,7 @@ def pretty_print_value(data):
     elif isinstance(data, list):
         return pretty_print_value_list(data)
     else:
-        return str(data)
+        return unicode(data)
 
 def pretty_print_table(data, max_col_width=50, headers=None):
     # redy to print lines


### PR DESCRIPTION
unicode seems to be what is indeed expected in other functions (such as
in tabulate)

close #7